### PR TITLE
Ensure import aliases aren't reserved keywords

### DIFF
--- a/jen/file_test.go
+++ b/jen/file_test.go
@@ -26,3 +26,19 @@ func TestGuessAlias(t *testing.T) {
 		}
 	}
 }
+
+func TestValidAlias(t *testing.T) {
+	data := map[string]bool{
+		"a":  true,
+		"b":  false,
+		"go": false,
+	}
+	f := NewFile("test")
+	f.register("b")
+	for alias, expected := range data {
+		if f.isValidAlias(alias) != expected {
+			fmt.Printf("isValidAlias test failed %s should return %t but got %t", alias, expected, f.isValidAlias(alias))
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
I ran into an issue with `Qual("github.com/opentracing/opentracing-go", "Tracer")` aliasing the import as `go`. I've added an additional check against Go's keyword tokens alongside the uniqueness check.