### PR TITLE
Add Slice function for defining type aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,16 @@ fmt.Printf("%#v", c)
 // a := b[1:]
 ```
 
+### Slice
+Slice renders square brackets followed by the keyword. Use for slice definitions.
+
+```go
+c := Type().Id("a").Slice(Byte())
+fmt.Printf("%#v", c)
+// Output:
+// type a []byte
+```
+
 ### Values
 Values renders a comma separated list enclosed by curly braces. Use for slice or composite literals.
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -217,6 +217,11 @@ Switch, Select, Case and Block are used to build switch or select statements:
 
 {{ "ExampleIndex_empty" | example }}
 
+### Slice
+{{ "Slice" | doc }}
+
+{{ "ExampleSlice" | example }}
+
 ### Values
 {{ "Values" | doc }}
 

--- a/genjen/data.go
+++ b/genjen/data.go
@@ -105,6 +105,15 @@ var groups = []struct {
 		parameters: []string{"typ"},
 	},
 	{
+		name:       "Slice",
+		comment:    "renders square brackets followed by the keyword. Use for slice definitions.",
+		variadic:   false,
+		opening:    "[]",
+		closing:    "",
+		separator:  "",
+		parameters: []string{"typ"},
+	},
+	{
 		name:       "If",
 		comment:    "renders the keyword followed by a semicolon separated list.",
 		variadic:   true,

--- a/jen/examples_test.go
+++ b/jen/examples_test.go
@@ -1081,6 +1081,13 @@ func ExampleMap() {
 	// a := map[string]string{}
 }
 
+func ExampleSlice() {
+	c := Type().Id("a").Slice(Byte())
+	fmt.Printf("%#v", c)
+	// Output:
+	// type a []byte
+}
+
 func ExampleDict() {
 	c := Id("a").Op(":=").Map(String()).String().Values(Dict{
 		Lit("a"): Lit("b"),

--- a/jen/generated.go
+++ b/jen/generated.go
@@ -429,6 +429,31 @@ func (s *Statement) Map(typ Code) *Statement {
 	return s
 }
 
+// Slice renders square brackets followed by the keyword. Use for slice definitions.
+func Slice(typ Code) *Statement {
+	return newStatement().Slice(typ)
+}
+
+// Slice renders square brackets followed by the keyword. Use for slice definitions.
+func (g *Group) Slice(typ Code) *Statement {
+	s := Slice(typ)
+	g.items = append(g.items, s)
+	return s
+}
+
+// Slice renders square brackets followed by the keyword. Use for slice definitions.
+func (s *Statement) Slice(typ Code) *Statement {
+	g := &Group{
+		close:     "",
+		items:     []Code{typ},
+		name:      "slice",
+		open:      "[]",
+		separator: "",
+	}
+	*s = append(*s, g)
+	return s
+}
+
 // If renders the keyword followed by a semicolon separated list.
 func If(conditions ...Code) *Statement {
 	return newStatement().If(conditions...)


### PR DESCRIPTION
A common need I have is to alias `[]byte` in order to attach methods. This commit adds a Slice function which renders the `[]` characters. A motivating example:

```go
c := Type().Id("a").Slice(Byte())
fmt.Printf("%#v", c)
```

Produces:

```go
type a []byte
```