### PR TITLE
allow all identifiers as aliases

### DIFF
--- a/jen/file.go
+++ b/jen/file.go
@@ -172,11 +172,9 @@ func guessAlias(path string) string {
 		alias = alias[strings.LastIndex(alias, "/")+1:]
 	}
 
-	// alias should be lower case
-	alias = strings.ToLower(alias)
-
-	// alias should now only contain alphanumerics
-	importsRegex := regexp.MustCompile(`[^a-z0-9]`)
+	// valid package identifiers are \p{L}[p{L}\p{Nd}_]?, so
+	// alias should only contain those characters classes
+	importsRegex := regexp.MustCompile(`[^\p{L}\p{Nd}_]`)
 	alias = importsRegex.ReplaceAllString(alias, "")
 
 	return alias

--- a/jen/file_test.go
+++ b/jen/file_test.go
@@ -8,8 +8,11 @@ import (
 func TestGuessAlias(t *testing.T) {
 
 	data := map[string]string{
-		"A":             "a",
+		"A":             "A",
 		"a":             "a",
+		"a0":            "a0",
+		"a_b":           "a_b",
+		"ß":             "ß",
 		"a$":            "a",
 		"a/b":           "b",
 		"a/b/c":         "c",


### PR DESCRIPTION
I've noticed my package name `github.com/a/b/foo_bar` ended up as
`package foobar` in the generated code when I pass
`github.com/a/b/foo_bar` to jen.NewFilePath().

The spec[1] says that the package clause has the format

    PackageClause  = "package" PackageName .
    PackageName    = identifier .

where identifier and letter are

    identifier = letter { letter | unicode_digit } .
    letter     = unicode_letter | "_" .

So this change allows more valid identifiers as guessed aliases,
concretely:

- no downcasing (`FooBar` would be a valid package name, albeit an odd
  one)
- keeping underscores in place
- not replacing the unicode alphanumerics outside of `[a-z0-9]`

[1]: https://golang.org/ref/spec#Package_clause