### PR TITLE
fix: alias can't have a first digit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dave/jennifer
+
+go 1.15

--- a/jen/file.go
+++ b/jen/file.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // NewFile Creates a new file, with the specified package name.
@@ -239,6 +241,11 @@ func guessAlias(path string) string {
 	// alias should now only contain alphanumerics
 	importsRegex := regexp.MustCompile(`[^a-z0-9]`)
 	alias = importsRegex.ReplaceAllString(alias, "")
+
+	// can't have a first digit, per Go identifier rules, so just skip them
+	for firstRune, runeLen := utf8.DecodeRuneInString(alias); unicode.IsDigit(firstRune); firstRune, runeLen = utf8.DecodeRuneInString(alias) {
+		alias = alias[runeLen:]
+	}
 
 	return alias
 }

--- a/jen/file_test.go
+++ b/jen/file_test.go
@@ -20,6 +20,8 @@ func TestGuessAlias(t *testing.T) {
 		"a/b-c.d":       "bcd",
 		"a/bb-ccc.dddd": "bbcccdddd",
 		"a/foo-go":      "foogo",
+		"123a":          "a",
+		"a/321a.b":      "ab",
 	}
 	for path, expected := range data {
 		if guessAlias(path) != expected {


### PR DESCRIPTION
**What this PR do**
fix an issue in guessAlias: alias can't have a first digit

**Before**
```
package test

import (
    11a "github.com/xxx/11a" // this is invalid
)
```

**After**
```
package test

import (
    a "github.com/xxx/11a" // this is valid
)
```
