### PR TITLE
Support for multiline strings

### DIFF
--- a/jen/examples_test.go
+++ b/jen/examples_test.go
@@ -558,6 +558,15 @@ func ExampleLit_string() {
 	// "foo"
 }
 
+func ExampleLit_newlineString() {
+	c := Lit(`Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`)
+	fmt.Printf("%#v", c)
+	// Output:
+	// `Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+	// sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`
+}
+
 func ExampleValues_dict_single() {
 	c := Map(String()).String().Values(Dict{
 		Lit("a"): Lit("b"),


### PR DESCRIPTION
Adds support for multiline strings. The decision to use multiline strings is to improve readability of strings, so long multiline strings are split into multiple lines and not printed as one long string with newline separators.

It uses a simple heuristics to choose whether to use single line or multiline string:

- string contains newlines and is longer than 50 characters
- there is not only newline at the end of string

I choose this heuristics as it's simple and should cover most of the cases, do you have some suggestions how to improve it?