### PR TITLE
Use %q to quote struct tag values

### DIFF
--- a/jen/examples_test.go
+++ b/jen/examples_test.go
@@ -1,9 +1,8 @@
 package jen_test
 
 import (
-	"fmt"
-
 	"bytes"
+	"fmt"
 
 	. "github.com/dave/jennifer/jen"
 )
@@ -1292,6 +1291,19 @@ func ExampleTag() {
 	// type foo struct {
 	// 	A string `json:"a"`
 	// 	B int    `bar:"baz" json:"b"`
+	// }
+}
+
+func ExampleTag_withQuotesAndNewline() {
+	c := Type().Id("foo").Struct(
+		Id("A").String().Tag(map[string]string{"json": "a"}),
+		Id("B").Int().Tag(map[string]string{"json": "b", "bar": "the value of\nthe\"bar\" tag"}),
+	)
+	fmt.Printf("%#v", c)
+	// Output:
+	// type foo struct {
+	// 	A string `json:"a"`
+	// 	B int    `bar:"the value of\nthe \"bar\" tag" json:"b"`
 	// }
 }
 

--- a/jen/tag.go
+++ b/jen/tag.go
@@ -59,7 +59,7 @@ func (t tag) render(f *File, w io.Writer, s *Statement) error {
 		if len(str) > 0 {
 			str += " "
 		}
-		str += fmt.Sprintf(`%s:"%s"`, k, v)
+		str += fmt.Sprintf(`%s:%q`, k, v)
 	}
 
 	if strconv.CanBackquote(str) {


### PR DESCRIPTION
Previously, it was possible to generate invalid struct tags because not all special characters inside the value are correctly quoted/escaped. Using `%q` delegates to strconv.Quote and ensures we have a valid go string.