### PR TITLE
Add LitRawString

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,19 @@ fmt.Printf("%#v", c)
 // a := 2
 ```
 
+LitRawString renders a raw string literal.
+
+```go
+c := Id("a").Op(":=").LitRawString("\n  some\n  formatted\n  multiline\n  string")
+fmt.Printf("%#v", c)
+// Output:
+// a := `
+//   some
+//   formatted
+//   multiline
+//   string`
+```
+
 For the default constant types (bool, int, float64, string, complex128), Lit 
 will render the untyped constant.
 

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -252,6 +252,10 @@ Note: the items are ordered by key when rendered to ensure repeatable code.
 
 {{ "ExampleLitFunc" | example }}
 
+{{ "LitRawString" | doc }}
+
+{{ "ExampleLitRawString" | example }}
+
 For the default constant types (bool, int, float64, string, complex128), Lit 
 will render the untyped constant.
 

--- a/jen/examples_test.go
+++ b/jen/examples_test.go
@@ -1169,6 +1169,17 @@ func ExampleLitFunc() {
 	// a := 2
 }
 
+func ExampleLitRawString() {
+	c := Id("a").Op(":=").LitRawString("\n  some\n  formatted\n  multiline\n  string")
+	fmt.Printf("%#v", c)
+	// Output:
+	// a := `
+	//   some
+	//   formatted
+	//   multiline
+	//   string`
+}
+
 func ExampleDot() {
 	c := Qual("a.b/c", "Foo").Call().Dot("Bar").Index(Lit(0)).Dot("Baz")
 	fmt.Printf("%#v", c)
@@ -1297,7 +1308,7 @@ func ExampleTag() {
 func ExampleTag_withQuotesAndNewline() {
 	c := Type().Id("foo").Struct(
 		Id("A").String().Tag(map[string]string{"json": "a"}),
-		Id("B").Int().Tag(map[string]string{"json": "b", "bar": "the value of\nthe\"bar\" tag"}),
+		Id("B").Int().Tag(map[string]string{"json": "b", "bar": "the value of\nthe \"bar\" tag"}),
 	)
 	fmt.Printf("%#v", c)
 	// Output:

--- a/jen/lit.go
+++ b/jen/lit.go
@@ -152,3 +152,50 @@ func (s *Statement) LitByteFunc(f func() byte) *Statement {
 	*s = append(*s, t)
 	return s
 }
+
+// LitRawString renders a raw string literal.
+func LitRawString(v interface{}) *Statement {
+	return newStatement().Lit(v)
+}
+
+// LitRawString renders a raw string literal.
+func (g *Group) LitRawString(v interface{}) *Statement {
+	s := Lit(v)
+	g.items = append(g.items, s)
+	return s
+}
+
+// LitRawString renders a raw string literal.
+func (s *Statement) LitRawString(v interface{}) *Statement {
+	t := token{
+		typ:     literalRawStringToken,
+		content: v,
+	}
+	*s = append(*s, t)
+	return s
+}
+
+// LitRawStringFunc renders a raw string literal. LitRawStringFunc generates the
+// value to render by executing the provided function.
+func LitRawStringFunc(f func() interface{}) *Statement {
+	return newStatement().LitRawStringFunc(f)
+}
+
+// LitRawStringFunc renders a raw string literal. LitRawStringFunc generates the
+// value to render by executing the provided function.
+func (g *Group) LitRawStringFunc(f func() interface{}) *Statement {
+	s := LitRawStringFunc(f)
+	g.items = append(g.items, s)
+	return s
+}
+
+// LitRawStringFunc renders a raw string literal. LitRawStringFunc generates the
+// value to render by executing the provided function.
+func (s *Statement) LitRawStringFunc(f func() interface{}) *Statement {
+	t := token{
+		typ:     literalRawStringToken,
+		content: f(),
+	}
+	*s = append(*s, t)
+	return s
+}

--- a/jen/tokens.go
+++ b/jen/tokens.go
@@ -10,17 +10,18 @@ import (
 type tokenType string
 
 const (
-	packageToken     tokenType = "package"
-	identifierToken  tokenType = "identifier"
-	qualifiedToken   tokenType = "qualified"
-	keywordToken     tokenType = "keyword"
-	operatorToken    tokenType = "operator"
-	delimiterToken   tokenType = "delimiter"
-	literalToken     tokenType = "literal"
-	literalRuneToken tokenType = "literal_rune"
-	literalByteToken tokenType = "literal_byte"
-	nullToken        tokenType = "null"
-	layoutToken      tokenType = "layout"
+	packageToken          tokenType = "package"
+	identifierToken       tokenType = "identifier"
+	qualifiedToken        tokenType = "qualified"
+	keywordToken          tokenType = "keyword"
+	operatorToken         tokenType = "operator"
+	delimiterToken        tokenType = "delimiter"
+	literalToken          tokenType = "literal"
+	literalRuneToken      tokenType = "literal_rune"
+	literalByteToken      tokenType = "literal_byte"
+	literalRawStringToken tokenType = "literal_rawString"
+	nullToken             tokenType = "null"
+	layoutToken           tokenType = "layout"
 )
 
 type token struct {
@@ -72,6 +73,10 @@ func (t token) render(f *File, w io.Writer, s *Statement) error {
 		}
 	case literalByteToken:
 		if _, err := w.Write([]byte(fmt.Sprintf("byte(%#v)", t.content))); err != nil {
+			return err
+		}
+	case literalRawStringToken:
+		if _, err := w.Write([]byte(fmt.Sprintf("`%v`", t.content.(string)))); err != nil {
 			return err
 		}
 	case keywordToken, operatorToken, layoutToken, delimiterToken:


### PR DESCRIPTION
This is purely a cosmetic feature - the issue I have at the moment is that my code generator has to create XML templates in the generated code, and I think it would look so much neater if I could insert them as raw strings so the final generated code is more readable. Obviously, it is completely functional without this feature, so it's no major loss if you feel this complicates the API too much.

Let me know what you think!