### PR TITLE
Handle case of nil literals in spec file

### DIFF
--- a/jen/examples_test.go
+++ b/jen/examples_test.go
@@ -1297,7 +1297,7 @@ func ExampleTag() {
 func ExampleTag_withQuotesAndNewline() {
 	c := Type().Id("foo").Struct(
 		Id("A").String().Tag(map[string]string{"json": "a"}),
-		Id("B").Int().Tag(map[string]string{"json": "b", "bar": "the value of\nthe\"bar\" tag"}),
+		Id("B").Int().Tag(map[string]string{"json": "b", "bar": "the value of\nthe \"bar\" tag"}),
 	)
 	fmt.Printf("%#v", c)
 	// Output:

--- a/jen/tokens.go
+++ b/jen/tokens.go
@@ -60,6 +60,8 @@ func (t token) render(f *File, w io.Writer, s *Statement) error {
 		case complex64:
 			// fmt package already renders parenthesis for complex64
 			out = fmt.Sprintf("%T%#v", t.content, t.content)
+		case nil:
+			// do nothing, consistent with nil types
 		default:
 			panic(fmt.Sprintf("unsupported type for literal: %T", t.content))
 		}


### PR DESCRIPTION
When handling null enums in spec files such as:

```
  sortOrder:
      nullable: true
      enum:
          - asc
          - desc
          - null
      readOnly: true
      type: string
```
Jennifer would translate the null variable into a literal 'literal: <nil>' and consequently throw a panic when the value type wouldn't match, instead of ignoring the null.

Null enums are perfectly valid according to swagger:
https://swagger.io/docs/specification/data-models/enums/

Also fixed a test that was failing (due to mismatch in input/output, not related to this issue)
                  