### PR TITLE
Fix typo in README(1.8->1.18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ fmt.Printf("%#v", c)
 # Generics
 [Identifiers](#identifiers) [Keywords](#keywords) [Operators](#operators) [Braces](#braces) [Parentheses](#parentheses) [Control flow](#control-flow) [Collections](#collections) [Literals](#literals) [Comments](#comments) **Generics** [Helpers](#helpers) [Misc](#misc) [File](#file)
 
-It is hoped that with the introduction of generics with Go 1.8, the need to generate code
+It is hoped that with the introduction of generics with Go 1.18, the need to generate code
 will be reduced. However, for the sake of completeness, we now support generics including
 the `any` and `comparable` predeclared identifiers, and the `Types` and `Union` lists. To
 emit the approximation (`~`) token, use `Op("~")`.

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -302,7 +302,7 @@ render rune and byte literals.
 # Generics
 [Identifiers](#identifiers) [Keywords](#keywords) [Operators](#operators) [Braces](#braces) [Parentheses](#parentheses) [Control flow](#control-flow) [Collections](#collections) [Literals](#literals) [Comments](#comments) **Generics** [Helpers](#helpers) [Misc](#misc) [File](#file)
 
-It is hoped that with the introduction of generics with Go 1.8, the need to generate code
+It is hoped that with the introduction of generics with Go 1.18, the need to generate code
 will be reduced. However, for the sake of completeness, we now support generics including
 the `any` and `comparable` predeclared identifiers, and the `Types` and `Union` lists. To
 emit the approximation (`~`) token, use `Op("~")`.


### PR DESCRIPTION
It looked like generics introduced in 1.18, so I fixed it.
After modifying `README.md.tpl`, I ran `go generate jennifer.go` and fixed it.
We have also confirmed that no changes have been made except for the target part.