### PR TITLE
add GoStringUnsafe for statements and groups

### DIFF
--- a/jen/group.go
+++ b/jen/group.go
@@ -129,6 +129,16 @@ func (g *Group) GoString() string {
 	return buf.String()
 }
 
+// GoStringUnsafe renders the Group for testing. The rendered code is not
+// formatted and not guaranteed to be valid Go code.
+func (g *Group) GoStringUnsafe() (string, error) {
+	buf := &bytes.Buffer{}
+	if err := g.render(NewFile(""), buf, nil); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // RenderWithFile renders the Group to the provided writer, using imports from the provided file.
 func (g *Group) RenderWithFile(writer io.Writer, file *File) error {
 	buf := &bytes.Buffer{}

--- a/jen/group_test.go
+++ b/jen/group_test.go
@@ -33,3 +33,28 @@ func TestGroup_Render(t *testing.T) {
 		t.Fatalf("Got: %v, expect: %v", got.String(), expect)
 	}
 }
+
+func TestGroup_GoStringUnsafe(t *testing.T) {
+	tt := []struct {
+		statement *Statement
+		expect    string
+	}{
+		{Func(), `func`},
+		{Map(String()).Int(), `map[string] int`},
+		{Interface(), `interface{}`},
+	}
+
+	for _, tc := range tt {
+		g := &Group{}
+		g.Add(tc.statement)
+
+		got, err := g.GoStringUnsafe()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != tc.expect {
+			t.Fatalf("Got: %v, expect: %v", got, tc.expect)
+		}
+	}
+}

--- a/jen/statement.go
+++ b/jen/statement.go
@@ -83,6 +83,16 @@ func (s *Statement) GoString() string {
 	return buf.String()
 }
 
+// GoStringUnsafe renders the Statement for testing. The rendered code is not
+// formatted and not guaranteed to be valid Go code.
+func (s *Statement) GoStringUnsafe() (string, error) {
+	buf := &bytes.Buffer{}
+	if err := s.render(NewFile(""), buf, nil); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
 // RenderWithFile renders the Statement to the provided writer, using imports from the provided file.
 func (s *Statement) RenderWithFile(writer io.Writer, file *File) error {
 	buf := &bytes.Buffer{}

--- a/jen/statement_test.go
+++ b/jen/statement_test.go
@@ -30,3 +30,25 @@ func TestStatement_Render(t *testing.T) {
 		t.Fatalf("Got: %v, expect: %v", got.String(), expect)
 	}
 }
+
+func TestStatement_GoStringUnsafe(t *testing.T) {
+	tt := []struct {
+		statement *Statement
+		expect    string
+	}{
+		{Func(), `func`},
+		{Map(String()).Int(), `map[string] int`},
+		{Interface(), `interface{}`},
+	}
+
+	for _, tc := range tt {
+		got, err := tc.statement.GoStringUnsafe()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got != tc.expect {
+			t.Fatalf("Got: %v, expect: %v", got, tc.expect)
+		}
+	}
+}


### PR DESCRIPTION
I've had a need to render statements that are not valid Go code. Unfortunately it doesn't seem like there's a way to ignore the gofmt in the existing `RenderWithFile`. Lemme know what you think!