### PR TITLE
Wrap error from go/format as it is scanner.ErrorList

### DIFF
--- a/jen/jen.go
+++ b/jen/jen.go
@@ -24,7 +24,7 @@ func (f *File) Save(filename string) error {
 	if err := f.Render(buf); err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(filename, buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(filename, buf.Bytes(), 0o644); err != nil {
 		return err
 	}
 	return nil
@@ -84,7 +84,7 @@ func (f *File) Render(w io.Writer) error {
 		var err error
 		output, err = format.Source(source.Bytes())
 		if err != nil {
-			return fmt.Errorf("Error %s while formatting source:\n%s", err, source.String())
+			return fmt.Errorf("Error %w while formatting source:\n%s", err, source.String())
 		}
 	}
 	if _, err := w.Write(output); err != nil {
@@ -94,7 +94,6 @@ func (f *File) Render(w io.Writer) error {
 }
 
 func (f *File) renderImports(source io.Writer) error {
-
 	// Render the "C" import if it's been used in a `Qual`, `Anon` or if there's a preamble comment
 	hasCgo := f.imports["C"].name != "" || len(f.cgoPreamble) > 0
 
@@ -144,7 +143,6 @@ func (f *File) renderImports(source io.Writer) error {
 				if _, err := fmt.Fprintf(source, "%s %s\n", def.name, strconv.Quote(path)); err != nil {
 					return err
 				}
-
 			} else {
 				if _, err := fmt.Fprintf(source, "%s\n", strconv.Quote(path)); err != nil {
 					return err


### PR DESCRIPTION
Hi, 

Using `jen` a lot lately (great project, btw). It was difficult to debug as the error is just a string with the resulting code which can be quite hard to figure out without doing properly formatting the resulting error. 

Since `go/format` returns a scanner.ErrorList error type, it would be nice to be able to `errors.As` to interact with the errors. This allow the code to be more like:

```go
err := f.Render(customJenCode)
if err != nil {
    var se scanner.ErrorList
    if errors.As(err, &se) {
	for _, e := range se {
		fmt.Printf("position: %+v", e.Pos)
		fmt.Println("message:", e.Msg)
	}
    }
    t.Fatal(err)
}

```

Currently, I'm using my fork and this is the best I could come up with:

```go
func jenDebug(err error) {
	es := err.Error()
	var se scanner.ErrorList
	if errors.As(err, &se) {
		for _, e := range se {
			// fmt.Println("line:", e.Pos.Line)
			// fmt.Println("column:", e.Pos.Column)
			// fmt.Println("message:", e.Msg)
			_, a, found := strings.Cut(es, e.Msg)
			if found {
				ss := strings.Split(a, "\n")
				for i, l := range ss {
					if i == e.Pos.Line {
						fmt.Printf("%d: %s  <---- ERROR: %s\n", i, l, e.Msg)
					} else {
						fmt.Printf("%d: %s\n", i, l)
					}
				}
				// fmt.Println("after:", a)
			}
		}
	}
}
```


This would help the debugging experience, not perfect by any means. 
Let me know what you think. 

Not an expert on the matter so I would appreciate to know how others debug generated code 😄 

